### PR TITLE
Fix Python dependency vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-requests==2.31.0
-httpx==0.25.0
+requests==2.32.0
+httpx==0.28.1
 pydantic==2.5.0
 typing-extensions==4.8.0
-certifi==2023.11.17
-aiohttp==3.9.5
-redis[async]==5.0.1
+certifi==2024.7.4
+aiohttp==3.10.11
+redis[async]==6.2.0
 sqlalchemy[asyncio]==2.0.23
 asyncpg==0.29.0


### PR DESCRIPTION
## Summary
- update `requests` to 2.32.0
- update `httpx` to 0.28.1 which brings in `httpcore`>=1.0.9 supporting `h11>=0.16`
- bump other packages flagged by `pip-audit`

## Testing
- `pip-audit -r requirements.txt`
- `pnpm audit --prod`


------
https://chatgpt.com/codex/tasks/task_e_6841bdf3ec78832082e721b5ebe2d554