### PR TITLE
Fix hard-coded base path for link validation

### DIFF
--- a/apps/api/app/services/link_validator.py
+++ b/apps/api/app/services/link_validator.py
@@ -9,6 +9,8 @@ import re
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urljoin
+from pathlib import Path
+import os
 from bs4 import BeautifulSoup
 import logging
 
@@ -333,7 +335,11 @@ async def validate_links_endpoint(urls: List[str]) -> Dict:
             }
         }
 
-async def generate_health_report_endpoint(base_path: str = "/Users/deepsleeping/agentlandos") -> Dict:
-    """API endpoint for comprehensive health report"""
+async def generate_health_report_endpoint(base_path: str | Path | None = None) -> Dict:
+    """API endpoint for comprehensive health report."""
+    if base_path is None:
+        base_path = Path(
+            os.getenv("AGENTLAND_ROOT", Path(__file__).resolve().parents[4])
+        )
     async with SaarlandLinkValidator() as validator:
-        return await validator.generate_link_health_report(base_path)
+        return await validator.generate_link_health_report(str(base_path))

--- a/apps/api/app/services/real_data/link_validation_service.py
+++ b/apps/api/app/services/real_data/link_validation_service.py
@@ -598,7 +598,9 @@ async def main():
         print("🔍 Starting comprehensive link validation for AGENTLAND.SAARLAND...")
         
         # Extract links from codebase
-        base_path = "/Users/deepsleeping/agentlandos"
+        base_path = Path(
+            os.getenv("AGENTLAND_ROOT", Path(__file__).resolve().parents[5])
+        )
         print(f"📂 Extracting links from {base_path}...")
         
         links = validator.extract_links_from_codebase(base_path)


### PR DESCRIPTION
## Summary
- remove hard-coded development path in link validation service
- make optional base path configurable via AGENTLAND_ROOT env var

## Testing
- `python -m py_compile apps/api/app/services/link_validator.py apps/api/app/services/real_data/link_validation_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6841bceccd448320b956a6f6a9dbc31b