### PR TITLE
Implement agent DB storage

### DIFF
--- a/apps/api/app/db/database.py
+++ b/apps/api/app/db/database.py
@@ -5,6 +5,9 @@ Datenbankverbindung und -konfiguration
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeMeta, declarative_base, sessionmaker
 
+# Import models so that Base.metadata is populated when creating tables
+from app.models import Agent, Feedback, analytics  # noqa: F401
+
 from app.core.config import settings
 
 # Async Engine erstellen - OPTIMIERT FÜR 200K USERS

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -1,0 +1,11 @@
+from .analytics import UserActivity, PageView, AgentInteraction
+from .feedback import Feedback
+from .agent import Agent
+
+__all__ = [
+    'UserActivity',
+    'PageView',
+    'AgentInteraction',
+    'Feedback',
+    'Agent',
+]

--- a/apps/api/app/models/agent.py
+++ b/apps/api/app/models/agent.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from sqlalchemy import Column, String, DateTime, Boolean, JSON
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+
+from app.db.database import Base
+
+class Agent(Base):
+    """Persisted agent metadata"""
+    __tablename__ = "agents"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    agent_id = Column(String, nullable=False, unique=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    capabilities = Column(JSON, nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)

--- a/apps/api/app/models/feedback.py
+++ b/apps/api/app/models/feedback.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from sqlalchemy import Column, String, DateTime, Integer, Text
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+
+from app.db.database import Base
+
+class Feedback(Base):
+    """User feedback for agent interactions"""
+    __tablename__ = "feedback"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    agent_id = Column(String, nullable=False, index=True)
+    message_id = Column(UUID(as_uuid=True), nullable=False)
+    rating = Column(Integer, nullable=False)
+    comment = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, index=True)


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for Agent and Feedback
- load agent metadata from the database
- save feedback records via database session
- register models so tables are created

## Testing
- `python -m py_compile apps/api/app/api/agents.py apps/api/app/models/agent.py apps/api/app/models/feedback.py apps/api/app/db/database.py`
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf491a6c8320a18d738f72a4888a