### PR TITLE
Improve chat performance and add Claude API

### DIFF
--- a/ai_docs/CHAT_AGENT_API.md
+++ b/ai_docs/CHAT_AGENT_API.md
@@ -1,0 +1,23 @@
+# Chat Agent API
+
+This endpoint exposes the Claude API via Next.js API routes.
+
+## Endpoint
+`/api/chat-agent`
+
+### Request
+```json
+{
+  "messages": [
+    { "role": "user", "content": "Hello" }
+  ],
+  "system": "optional system prompt"
+}
+```
+
+### Response
+```json
+{ "role": "assistant", "content": "response text" }
+```
+
+The handler uses `@anthropic-ai/sdk` and expects `ANTHROPIC_API_KEY` to be set.

--- a/ai_docs/UPDATED_FUNCTIONS.md
+++ b/ai_docs/UPDATED_FUNCTIONS.md
@@ -1,0 +1,12 @@
+# Updated Components
+
+## DeepSeekServiceChat
+- Memoized service configuration with `useMemo`
+- Converted message handlers to `useCallback`
+- Applied Quantum Sans and Nova Text fonts
+
+## InteractiveSaarlandMap
+- Memoized icon configuration using `useMemo`
+- Added `useCallback` for icon creation and navigation helpers
+
+These optimizations reduce re-renders and improve perceived speed.

--- a/apps/web/src/components/DeepSeekServiceChat.tsx
+++ b/apps/web/src/components/DeepSeekServiceChat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Send, Loader2, Download, Share2, RefreshCw, Bot, User, FileText, Map, Calculator, Presentation } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -71,16 +71,16 @@ export default function DeepSeekServiceChat({
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const config = serviceConfig[serviceType]
+  const config = useMemo(() => serviceConfig[serviceType], [serviceType])
 
   // Auto-scroll to bottom
-  const scrollToBottom = () => {
+  const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }
+  }, [])
 
   useEffect(() => {
     scrollToBottom()
-  }, [messages])
+  }, [messages, scrollToBottom])
 
   // Initialize with welcome message
   useEffect(() => {
@@ -98,7 +98,7 @@ export default function DeepSeekServiceChat({
   }, [serviceType, initialMessage])
 
   // Send message to DeepSeek API
-  const handleSendMessage = async (messageText?: string) => {
+  const handleSendMessage = useCallback(async (messageText?: string) => {
     const text = messageText || input.trim()
     if (!text) return
 
@@ -159,18 +159,21 @@ export default function DeepSeekServiceChat({
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [input, messages, serviceType, sessionId])
 
   // Handle Enter key
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSendMessage()
-    }
-  }
+  const handleKeyPress = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        handleSendMessage()
+      }
+    },
+    [handleSendMessage]
+  )
 
   // Export canvas data
-  const handleExportCanvas = (canvas: CanvasData) => {
+  const handleExportCanvas = useCallback((canvas: CanvasData) => {
     const blob = new Blob([JSON.stringify(canvas, null, 2)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -180,10 +183,10 @@ export default function DeepSeekServiceChat({
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
-  }
+  }, [])
 
   // Render canvas component based on type
-  const renderCanvas = (canvas: CanvasData) => {
+  const renderCanvas = useCallback((canvas: CanvasData) => {
     switch (canvas.type) {
       case 'roadmap':
         return <RoadmapCanvas data={canvas.data} title={canvas.title} />
@@ -198,7 +201,7 @@ export default function DeepSeekServiceChat({
       default:
         return <GenericCanvas data={canvas.data} title={canvas.title} />
     }
-  }
+  }, [])
 
   return (
     <div className={`flex flex-col h-full bg-white rounded-xl border border-gray-200 shadow-lg overflow-hidden ${className}`}>
@@ -207,11 +210,11 @@ export default function DeepSeekServiceChat({
         <div className={`bg-gradient-to-r ${config.color} p-4 text-white`}>
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-xl font-bold flex items-center">
+              <h2 className="text-xl font-bold flex items-center font-quantum">
                 <span className="text-2xl mr-2">{config.icon}</span>
                 {config.title}
               </h2>
-              <p className="text-sm opacity-90 mt-1">{config.subtitle}</p>
+              <p className="text-sm opacity-90 mt-1 font-nova">{config.subtitle}</p>
             </div>
             <div className="flex items-center space-x-2">
               <Button
@@ -260,7 +263,7 @@ export default function DeepSeekServiceChat({
                     <User className="w-5 h-5 text-white mt-0.5 flex-shrink-0" />
                   )}
                   <div className="flex-1">
-                    <div className="whitespace-pre-wrap">{message.content}</div>
+                    <div className="whitespace-pre-wrap font-nova">{message.content}</div>
                     <div className="text-xs opacity-70 mt-1">
                       {message.timestamp.toLocaleTimeString()}
                     </div>
@@ -272,7 +275,7 @@ export default function DeepSeekServiceChat({
               {message.canvas && (
                 <div className="mt-3 p-4 bg-gray-50 rounded-lg border">
                   <div className="flex items-center justify-between mb-3">
-                    <h4 className="font-semibold text-gray-900 flex items-center">
+                    <h4 className="font-semibold text-gray-900 flex items-center font-quantum">
                       <Presentation className="w-4 h-4 mr-2" />
                       {message.canvas.title}
                     </h4>
@@ -322,7 +325,7 @@ export default function DeepSeekServiceChat({
             onKeyPress={handleKeyPress}
             placeholder={config.placeholder}
             disabled={isLoading}
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 font-nova"
           />
           <Button
             onClick={() => handleSendMessage()}

--- a/apps/web/src/components/InteractiveSaarlandMap.tsx
+++ b/apps/web/src/components/InteractiveSaarlandMap.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import { MapPin, Navigation, Info, Calendar, Euro, ExternalLink, AlertCircle } from 'lucide-react';
 
 // Dynamic import for Leaflet (client-side only)
@@ -171,8 +171,8 @@ export default function InteractiveSaarlandMap({
     }
   };
 
-  const getIconForCategory = (category: string) => {
-    const iconConfig: Record<string, { color: string; symbol: string }> = {
+  const iconConfig = useMemo(
+    () => ({
       tourist_attractions: { color: '#3B82F6', symbol: '🏞️' },
       education: { color: '#10B981', symbol: '🎓' },
       culture: { color: '#8B5CF6', symbol: '🎭' },
@@ -183,15 +183,19 @@ export default function InteractiveSaarlandMap({
       leisure: { color: '#14B8A6', symbol: '🛍️' },
       nature: { color: '#22C55E', symbol: '🌳' },
       cities: { color: '#0EA5E9', symbol: '🏘️' }
-    };
-    
-    const config = iconConfig[category] || { color: '#9CA3AF', symbol: '📍' };
-    
-    return L.divIcon({
-      className: 'custom-div-icon',
-      html: `
-        <div style="
-          background-color: ${config.color}; 
+    }),
+    []
+  );
+
+  const getIconForCategory = useCallback(
+    (category: string) => {
+      const config = iconConfig[category] || { color: '#9CA3AF', symbol: '📍' };
+
+      return L.divIcon({
+        className: 'custom-div-icon',
+        html: `
+          <div style="
+            background-color: ${config.color};
           width: 32px; 
           height: 32px; 
           border-radius: 50%; 
@@ -203,13 +207,15 @@ export default function InteractiveSaarlandMap({
           font-size: 16px;
         ">${config.symbol}</div>
       `,
-      iconSize: [32, 32],
-      iconAnchor: [16, 16],
-      popupAnchor: [0, -16]
-    });
-  };
+        iconSize: [32, 32],
+        iconAnchor: [16, 16],
+        popupAnchor: [0, -16]
+      });
+    },
+    [iconConfig]
+  );
 
-  const createPopupContent = (poi: POI) => {
+  const createPopupContent = useCallback((poi: POI) => {
     return `
       <div style="min-width: 200px;">
         <h3 style="margin: 0 0 8px 0; font-weight: bold;">${poi.name}</h3>
@@ -224,23 +230,23 @@ export default function InteractiveSaarlandMap({
         </div>
       </div>
     `;
-  };
+  }, []);
 
-  const navigateToPOI = (poi: POI) => {
+  const navigateToPOI = useCallback((poi: POI) => {
     if (mapInstanceRef.current) {
       mapInstanceRef.current.setView([poi.lat, poi.lon], 15, {
         animate: true,
         duration: 1
       });
     }
-  };
+  }, []);
 
-  const openDirections = (poi: POI) => {
+  const openDirections = useCallback((poi: POI) => {
     const url = `https://www.openstreetmap.org/directions?to=${poi.lat},${poi.lon}`;
     if (typeof window !== 'undefined') {
       window.open(url, '_blank');
     }
-  };
+  }, []);
 
   return (
     <div className="relative">

--- a/apps/web/src/pages/api/chat-agent.ts
+++ b/apps/web/src/pages/api/chat-agent.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Anthropic } from '@anthropic-ai/sdk'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { messages, system } = req.body || {}
+
+  if (!Array.isArray(messages)) {
+    return res.status(400).json({ error: 'messages array required' })
+  }
+
+  try {
+    const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY || '' })
+    const completion = await anthropic.messages.create({
+      model: 'claude-3-sonnet-20240229',
+      max_tokens: 1024,
+      system: system || 'You are a helpful assistant for the Saarland region.',
+      messages,
+    })
+
+    const content = completion.content?.[0]?.text ?? ''
+
+    return res.status(200).json({ role: 'assistant', content })
+  } catch (err: any) {
+    console.error('Claude API error', err)
+    return res.status(500).json({ error: 'Claude API error' })
+  }
+}


### PR DESCRIPTION
## Summary
- add Claude-based chat API
- optimize `DeepSeekServiceChat` with memoization, callbacks, and brand fonts
- tune `InteractiveSaarlandMap` helpers with memoization and callbacks
- document new API and function updates

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d7157a348320aa7f4019da2d5b7d