### PR TITLE
Fix docs and scripts, add basic tests

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ Diese Vercel Serverless Functions bilden das Backend für AGENT_LAND_SAARLAND.
 ### `/api/health`
 - **Methode**: GET
 - **Beschreibung**: Health-Check Endpoint
-- **Response**: `{"status": "ok", "service": "AGENT_LAND_SAARLAND"}`
+- **Response**: `{"status": "healthy", "service": "AGENT_LAND_SAARLAND"}`
 
 ### `/api/saartasks`
 - **Methode**: GET, POST

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -55,3 +55,7 @@ python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,0 +1,29 @@
+import json
+import os
+import sys
+from io import BytesIO
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api import health
+
+class MockHealthHandler(health.handler):
+    def __init__(self):
+        self.wfile = BytesIO()
+
+    def send_response(self, code):
+        self.status_code = code
+
+    def send_header(self, *args, **kwargs):
+        pass
+
+    def end_headers(self):
+        pass
+
+def test_health_handler():
+    handler = MockHealthHandler()
+    handler.do_GET()
+    handler.wfile.seek(0)
+    data = json.loads(handler.wfile.read().decode())
+    assert handler.status_code == 200
+    assert data["status"] == "healthy"

--- a/apps/api/tests/test_saartasks.py
+++ b/apps/api/tests/test_saartasks.py
@@ -1,0 +1,22 @@
+import asyncio
+import os
+import sys
+
+import pytest
+pytest_plugins = "pytest_asyncio"
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api import saartasks
+
+class MockSaarHandler(saartasks.handler):
+    def __init__(self):
+        pass
+
+@pytest.mark.asyncio
+async def test_saartasks_fallback(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    handler = MockSaarHandler()
+    result = await handler.process_saartask("Hallo", "de")
+    assert result["metadata"]["mode"] == "fallback"
+    assert result["agent_id"] == "saartasks"

--- a/scripts/ci-cd-pipeline.sh
+++ b/scripts/ci-cd-pipeline.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-AGENTLAND_ROOT="/Users/deepsleeping/agentlandos"
+AGENTLAND_ROOT="$(git rev-parse --show-toplevel)"
 LOG_FILE="$AGENTLAND_ROOT/ai_docs/ci-cd-pipeline.log"
 
 # Colors

--- a/scripts/deploy-check.sh
+++ b/scripts/deploy-check.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# AGENT_LAND_SAARLAND - Vercel Deployment Helper
+# AGENTLAND.SAARLAND - Vercel Deployment Helper
 # ==============================================
 
-echo "🚀 AGENT_LAND_SAARLAND - Deployment Vorbereitung"
+echo "🚀 AGENTLAND.SAARLAND - Deployment Vorbereitung"
 echo "=============================================="
 
 # Schritt 1: Überprüfe Node.js Version
@@ -55,4 +55,4 @@ echo "   - REDIS_URL"
 echo ""
 echo "2. Deploye mit: npx vercel --prod"
 echo ""
-echo "🌟 Viel Erfolg mit AGENT_LAND_SAARLAND!"
+echo "🌟 Viel Erfolg mit AGENTLAND.SAARLAND!"

--- a/scripts/vercel-deploy-qa.sh
+++ b/scripts/vercel-deploy-qa.sh
@@ -14,7 +14,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-PROJECT_ROOT="/Users/deepsleeping/agentlandos"
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 WEB_APP_PATH="$PROJECT_ROOT/apps/web"
 API_APP_PATH="$PROJECT_ROOT/apps/api"
 QA_REPORT_PATH="$PROJECT_ROOT/ai_docs/qa-reports"

--- a/scripts/vercel-deploy.sh
+++ b/scripts/vercel-deploy.sh
@@ -36,8 +36,9 @@ fi
 
 echo ""
 
-# Set project directory
-cd /Users/deepsleeping/agentlandos/apps/web
+# Set project directory dynamically
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT/apps/web"
 
 echo "📁 Working Directory: $(pwd)"
 echo "🌐 Target Domain: agentland.saarland"


### PR DESCRIPTION
## Summary
- document correct health endpoint response
- make deployment scripts work from any directory
- unify naming in deploy-check helper
- add pytest config and basic API tests

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r apps/api/requirements.txt`
- `pip install -q pytest-asyncio`
- `pytest -q apps/api/tests`

------
https://chatgpt.com/codex/tasks/task_e_6841bcecdad083208326e5862e5a6ab9