### PR TITLE
Add health and saartasks tests

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -55,3 +55,6 @@ python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+# ensure package path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.main_simple import app
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json().get("status") == "healthy"

--- a/apps/api/tests/test_saartasks.py
+++ b/apps/api/tests/test_saartasks.py
@@ -1,0 +1,16 @@
+import sys
+import os
+import asyncio
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api.saartasks import handler
+
+
+def test_saartasks_fallback(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    inst = handler.__new__(handler)
+    result = asyncio.run(inst.process_saartask("Hallo", "de"))
+    assert result["metadata"]["mode"] == "fallback"
+    assert result["agent_id"] == "saartasks"


### PR DESCRIPTION
## Summary
- add pytest cases for the FastAPI health endpoint and saartasks fallback logic
- include new tests path in pyproject

## Testing
- `pytest apps/api/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f82b26e8832090582c1f3bb2c2fc