### PR TITLE
Implement Claude agent API with Supabase memory

### DIFF
--- a/ai_docs/agent-system.md
+++ b/ai_docs/agent-system.md
@@ -1,0 +1,29 @@
+# Agent System
+
+## New API Endpoint
+
+`POST /api/agent`
+
+- Streams responses from Claude 3.5 using Server-Sent Events.
+- Persists conversation history in the `agent_history` table.
+- Requires authentication via middleware.
+
+### Request Body
+```json
+{ "message": "text", "sessionId": "optional" }
+```
+
+### Response
+Streaming text chunks forming the assistant reply.
+
+## Frontend Chat
+
+`/chat`
+
+- Uses Supabase real-time subscriptions to reflect new messages instantly.
+- Persists session id in browser storage for memory.
+- Styled with Saarland brand colors and fonts.
+
+## Authentication Middleware
+
+Middleware now uses `withMiddlewareAuth` from `@supabase/auth-helpers-nextjs` to protect pages and API routes.

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,33 +1,28 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs'
 
-export async function middleware(request: NextRequest) {
-  const response = NextResponse.next();
-  
+async function baseMiddleware(request: NextRequest) {
+  const response = NextResponse.next()
+
   // Basic security headers
-  response.headers.set('X-Content-Type-Options', 'nosniff');
-  response.headers.set('X-Frame-Options', 'DENY');
-  response.headers.set('X-XSS-Protection', '1; mode=block');
-  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  
+  response.headers.set('X-Content-Type-Options', 'nosniff')
+  response.headers.set('X-Frame-Options', 'DENY')
+  response.headers.set('X-XSS-Protection', '1; mode=block')
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+
   // Custom headers
-  response.headers.set('X-Powered-By', 'AGENTLAND.SAARLAND');
-  response.headers.set('X-Region', 'Saarland');
-  response.headers.set('X-Version', '2.0.0');
-  
-  return response;
+  response.headers.set('X-Powered-By', 'AGENTLAND.SAARLAND')
+  response.headers.set('X-Region', 'Saarland')
+  response.headers.set('X-Version', '2.0.0')
+
+  return response
 }
+
+export const middleware = withMiddlewareAuth(baseMiddleware)
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - api/health (public health check)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - public folder files
-     */
     '/((?!_next/static|_next/image|favicon.ico|public/).*)',
   ],
-};
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@stripe/stripe-js": "^7.3.1",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.49.10",
     "@tanstack/react-query": "^5.80.6",
     "@types/leaflet": "^1.9.18",

--- a/apps/web/pages/api/agent.ts
+++ b/apps/web/pages/api/agent.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createClient } from '@supabase/supabase-js'
+import { Anthropic } from '@anthropic-ai/sdk'
+
+// Initialize Supabase client using service role for server-side operations
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+/**
+ * API route providing streaming Claude responses with session-based memory.
+ * Expected body: { message: string, sessionId?: string }
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { message, sessionId } = req.body as { message?: string; sessionId?: string }
+  if (!message) return res.status(400).json({ error: 'Message required' })
+
+  // Fetch existing conversation memory for the session
+  let history: { role: 'user' | 'assistant'; content: string }[] = []
+  if (sessionId) {
+    const { data } = await supabase
+      .from('agent_history')
+      .select('role, content')
+      .eq('session_id', sessionId)
+      .order('id', { ascending: true })
+    history = (data as any[]) || []
+  }
+
+  const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! })
+  const systemPrompt = 'AgentNet ist unsere Antwort auf das tote Internet – Wissen lebt hier.'
+
+  // Build conversation for Claude
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    ...history,
+    { role: 'user', content: message }
+  ] as any
+
+  const stream = await anthropic.messages.create({
+    model: 'claude-3.5-sonnet-20240620',
+    max_tokens: 1024,
+    stream: true,
+    messages
+  })
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  })
+
+  let assistantText = ''
+  for await (const chunk of stream) {
+    const text = chunk.delta?.text || ''
+    assistantText += text
+    res.write(text)
+  }
+  res.end()
+
+  // Persist conversation to Supabase for future memory
+  if (sessionId) {
+    await supabase.from('agent_history').insert([
+      { session_id: sessionId, role: 'user', content: message },
+      { session_id: sessionId, role: 'assistant', content: assistantText }
+    ])
+  }
+}

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from 'react'
+import { createClient } from '@supabase/supabase-js'
+import { v4 as uuid } from 'uuid'
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const sessionIdRef = useRef('')
+
+  // Ensure session id in browser storage
+  useEffect(() => {
+    let id = sessionStorage.getItem('agent-session')
+    if (!id) {
+      id = uuid()
+      sessionStorage.setItem('agent-session', id)
+    }
+    sessionIdRef.current = id
+
+    // Subscribe to history table for real-time updates
+    const channel = supabase
+      .channel('agent-history')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'agent_history', filter: `session_id=eq.${id}` },
+        payload => {
+          setMessages(m => [...m, { role: payload.new.role, content: payload.new.content }])
+        }
+      )
+      .subscribe()
+
+    return () => { channel.unsubscribe() }
+  }, [])
+
+  const sendMessage = async () => {
+    if (!input.trim()) return
+    const userText = input
+    setMessages(m => [...m, { role: 'user', content: userText }])
+    setInput('')
+
+    const res = await fetch('/api/agent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: userText, sessionId: sessionIdRef.current })
+    })
+
+    if (!res.ok) return
+    const reader = res.body!.getReader()
+    let assistantText = ''
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      const chunk = new TextDecoder().decode(value)
+      assistantText += chunk
+      setMessages(m => {
+        const last = m[m.length - 1]
+        if (last && last.role === 'assistant') {
+          return [...m.slice(0, -1), { ...last, content: assistantText }]
+        }
+        return [...m, { role: 'assistant', content: assistantText }]
+      })
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 font-sans">
+      <div className="max-w-2xl mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4 text-saarland-blue">AgentNet Chat</h1>
+        <div className="space-y-2 mb-4">
+          {messages.map((m, i) => (
+            <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+              <span className={m.role === 'user' ? 'bg-saarland-blue text-white px-2 py-1 rounded-lg' : 'bg-gray-200 px-2 py-1 rounded-lg'}>{m.content}</span>
+            </div>
+          ))}
+        </div>
+        <div className="flex space-x-2">
+          <input
+            className="flex-1 border border-gray-300 rounded px-3 py-2"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            placeholder="Frag etwas..."
+          />
+          <button
+            onClick={sendMessage}
+            className="bg-saarland-blue text-white px-4 py-2 rounded"
+          >
+            Senden
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@stripe/stripe-js':
         specifier: ^7.3.1
         version: 7.3.1
+      '@supabase/auth-helpers-nextjs':
+        specifier: ^0.10.0
+        version: 0.10.0(@supabase/supabase-js@2.49.10)
       '@supabase/supabase-js':
         specifier: ^2.49.10
         version: 2.49.10
@@ -1638,6 +1641,18 @@ packages:
   '@stripe/stripe-js@7.3.1':
     resolution: {integrity: sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==}
     engines: {node: '>=12.16'}
+
+  '@supabase/auth-helpers-nextjs@0.10.0':
+    resolution: {integrity: sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==}
+    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
+    peerDependencies:
+      '@supabase/supabase-js': ^2.39.8
+
+  '@supabase/auth-helpers-shared@0.7.0':
+    resolution: {integrity: sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==}
+    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
+    peerDependencies:
+      '@supabase/supabase-js': ^2.39.8
 
   '@supabase/auth-js@2.69.1':
     resolution: {integrity: sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==}
@@ -3264,6 +3279,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-tiktoken@1.0.20:
     resolution: {integrity: sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==}
 
@@ -4157,6 +4175,9 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6435,6 +6456,17 @@ snapshots:
 
   '@stripe/stripe-js@7.3.1': {}
 
+  '@supabase/auth-helpers-nextjs@0.10.0(@supabase/supabase-js@2.49.10)':
+    dependencies:
+      '@supabase/auth-helpers-shared': 0.7.0(@supabase/supabase-js@2.49.10)
+      '@supabase/supabase-js': 2.49.10
+      set-cookie-parser: 2.7.1
+
+  '@supabase/auth-helpers-shared@0.7.0(@supabase/supabase-js@2.49.10)':
+    dependencies:
+      '@supabase/supabase-js': 2.49.10
+      jose: 4.15.9
+
   '@supabase/auth-js@2.69.1':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -7570,7 +7602,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -7600,7 +7632,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.11
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7615,7 +7647,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8366,6 +8398,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@1.21.7: {}
+
+  jose@4.15.9: {}
 
   js-tiktoken@1.0.20:
     dependencies:
@@ -9211,6 +9245,8 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- add streaming Claude 3.5 API route using Supabase for memory
- create real-time chat page with Supabase subscriptions
- enforce auth with withMiddlewareAuth middleware
- document agent system features
- update dependencies for auth helpers

## Testing
- `pnpm lint` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6842f850beb8832098646e9999d99859