### PR TITLE
Implement cross-border API endpoints

### DIFF
--- a/apps/api/app/api/cross_border.py
+++ b/apps/api/app/api/cross_border.py
@@ -1,0 +1,58 @@
+"""Cross-Border Services API"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+
+from app.services.cross_border_service import (
+    calculate_cross_border_tax,
+    search_cross_border_healthcare,
+)
+
+router = APIRouter(
+    prefix="/api/v1/cross-border",
+    tags=["cross-border"],
+)
+
+
+class TaxRequest(BaseModel):
+    residence_country: str = Field(..., pattern="^(DE|FR|LU)$")
+    work_country: str = Field(..., pattern="^(DE|FR|LU)$")
+    annual_income: float = Field(..., ge=0)
+    family_status: Optional[str] = "single"
+    children_count: Optional[int] = 0
+    special_circumstances: Optional[List[str]] = None
+
+
+@router.post("/tax-calculator")
+async def tax_calculator(req: TaxRequest) -> Dict[str, Any]:
+    """Calculate income tax for cross-border workers."""
+    try:
+        data = await calculate_cross_border_tax(
+            req.residence_country,
+            req.work_country,
+            req.annual_income,
+            req.family_status,
+            req.children_count,
+            req.special_circumstances,
+        )
+        return {"status": "success", "data": data}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/healthcare/search")
+async def healthcare_search(
+    location: str,
+    specialty: Optional[str] = None,
+    language: str = "de",
+    radius_km: int = 50,
+) -> Dict[str, Any]:
+    """Find cross-border doctors and hospitals."""
+    try:
+        results = await search_cross_border_healthcare(
+            location, specialty, language, radius_km
+        )
+        return {"status": "success", "providers": results}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/app/data/cross_border_tax_rates.json
+++ b/apps/api/app/data/cross_border_tax_rates.json
@@ -1,0 +1,17 @@
+{
+  "DE": {
+    "allowance": 11604,
+    "flat_rate": 0.42,
+    "description": "Top income tax rate for Germany 2024"
+  },
+  "FR": {
+    "allowance": 10225,
+    "flat_rate": 0.45,
+    "description": "Top income tax rate for France 2024"
+  },
+  "LU": {
+    "allowance": 11570,
+    "flat_rate": 0.42,
+    "description": "Top income tax rate for Luxembourg 2024"
+  }
+}

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -10,7 +10,16 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
 from app.db.database import create_db_and_tables, engine
-from app.api import agents_router, auth, health, users, enhanced_agents, realtime, performance
+from app.api import (
+    agents_router,
+    auth,
+    health,
+    users,
+    enhanced_agents,
+    realtime,
+    performance,
+    cross_border,
+)
 from app.middleware.performance import PerformanceMiddleware, MemoryOptimizationMiddleware
 
 
@@ -74,6 +83,7 @@ app.include_router(agents_router.router, prefix="/api/v1", tags=["KI-Agenten"])
 app.include_router(enhanced_agents.router, tags=["Enhanced KI-Agenten"])
 app.include_router(realtime.router, tags=["Echtzeit-Daten"])
 app.include_router(performance.router, tags=["Performance-Monitoring"])
+app.include_router(cross_border.router, tags=["Cross-Border"])
 
 
 @app.get("/", tags=["Root"])

--- a/apps/api/app/services/cross_border_service.py
+++ b/apps/api/app/services/cross_border_service.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, List
+
+import httpx
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "data" / "cross_border_tax_rates.json"
+
+with DATA_FILE.open() as f:
+    TAX_DATA = json.load(f)
+
+
+async def calculate_cross_border_tax(
+    residence_country: str,
+    work_country: str,
+    annual_income: float,
+    family_status: str = "single",
+    children_count: int = 0,
+    special_circumstances: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Calculate simplified income tax using real tax rate data."""
+
+    residence_info = TAX_DATA.get(residence_country)
+    work_info = TAX_DATA.get(work_country)
+    if not residence_info or not work_info:
+        raise ValueError("Unsupported country code")
+
+    taxable_income = max(0, annual_income - residence_info["allowance"])
+    tax_due = taxable_income * work_info["flat_rate"]
+
+    return {
+        "residence_country": residence_country,
+        "work_country": work_country,
+        "taxable_income": taxable_income,
+        "tax_rate": work_info["flat_rate"],
+        "tax_due": round(tax_due, 2),
+    }
+
+
+async def search_cross_border_healthcare(
+    location: str,
+    specialty: Optional[str] = None,
+    language: str = "de",
+    radius_km: int = 50,
+) -> List[Dict[str, Any]]:
+    """Search doctors or hospitals across borders using the public Nominatim API."""
+
+    query = specialty if specialty else "doctor"
+    params = {
+        "q": f"{query} {location}",
+        "format": "json",
+        "limit": 10,
+    }
+    headers = {"User-Agent": "agentland-os/1.0", "Accept-Language": language}
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get("https://nominatim.openstreetmap.org/search", params=params, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+    results = [
+        {
+            "name": item.get("display_name"),
+            "lat": item.get("lat"),
+            "lon": item.get("lon"),
+        }
+        for item in data
+    ]
+
+    return results


### PR DESCRIPTION
## Summary
- create cross-border tax dataset
- add cross-border service functions
- expose `/api/v1/cross-border` routes
- register router in the FastAPI app

## Testing
- `python -m py_compile apps/api/app/api/cross_border.py apps/api/app/services/cross_border_service.py`
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fc6626c88320808537f6d95e435a