### PR TITLE
Add tutorial overlay for first-time visitors

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
+import Providers from './providers'
+import GlobalTutorial from '@/components/GlobalTutorial'
 
 // Brandbook-compliant fonts
 const inter = Inter({ 
@@ -198,7 +200,10 @@ export default function RootLayout({
         }} />
       </head>
       <body className="font-nova text-neutral-gray bg-white antialiased">
-        {children}
+        <Providers>
+          {children}
+          <GlobalTutorial />
+        </Providers>
       </body>
     </html>
   )

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { ReactNode } from 'react'
+import { AuthProvider } from '@/contexts/AuthContext'
+import { TutorialProvider } from '@/contexts/TutorialContext'
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return (
+    <AuthProvider>
+      <TutorialProvider>
+        {children}
+      </TutorialProvider>
+    </AuthProvider>
+  )
+}

--- a/apps/web/src/components/GlobalTutorial.tsx
+++ b/apps/web/src/components/GlobalTutorial.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useState } from 'react'
+import { useTutorial } from '@/contexts/TutorialContext'
+import { Button } from '@/components/ui/button'
+
+export default function GlobalTutorial() {
+  const { showTutorial, finishTutorial } = useTutorial()
+  const [step, setStep] = useState(0)
+
+  if (!showTutorial) return null
+
+  const steps = [
+    'Willkommen bei AGENTLAND.SAARLAND! Dieses Tutorial zeigt Ihnen die wichtigsten Bereiche.',
+    'Oben finden Sie das Menü mit Zugriff auf Chat, Canvas und Services.',
+    'Viel Spaß beim Entdecken unserer KI-Angebote!'
+  ]
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1)
+    } else {
+      finishTutorial()
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+      <div className="bg-white p-6 rounded-xl max-w-sm text-center space-y-4">
+        <p>{steps[step]}</p>
+        <Button onClick={next}>{step < steps.length - 1 ? 'Weiter' : 'Fertig'}</Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/contexts/TutorialContext.tsx
+++ b/apps/web/src/contexts/TutorialContext.tsx
@@ -1,0 +1,47 @@
+'use client'
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { AuthService } from '@/lib/supabase'
+
+interface TutorialContextValue {
+  showTutorial: boolean
+  finishTutorial: () => void
+}
+
+const TutorialContext = createContext<TutorialContextValue>({
+  showTutorial: false,
+  finishTutorial: () => {}
+})
+
+export function TutorialProvider({ children }: { children: React.ReactNode }) {
+  const [showTutorial, setShowTutorial] = useState(false)
+
+  useEffect(() => {
+    async function check() {
+      try {
+        const user = await AuthService.getCurrentUser()
+        const visited = localStorage.getItem('tutorial_seen')
+        if (!visited || !user) {
+          setShowTutorial(true)
+        }
+      } catch {
+        setShowTutorial(true)
+      }
+    }
+    check()
+  }, [])
+
+  const finishTutorial = () => {
+    localStorage.setItem('tutorial_seen', 'true')
+    setShowTutorial(false)
+  }
+
+  return (
+    <TutorialContext.Provider value={{ showTutorial, finishTutorial }}>
+      {children}
+    </TutorialContext.Provider>
+  )
+}
+
+export function useTutorial() {
+  return useContext(TutorialContext)
+}


### PR DESCRIPTION
## Summary
- show interactive tutorial overlay if user not seen tutorial or isn't logged in
- add tutorial context and provider setup
- wire providers into global layout

## Testing
- `pnpm typecheck` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_684302c382088320a2127ffaeef5c216